### PR TITLE
feat: Implement open htlm report in browser by defaul

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +459,17 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dbus"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1169,6 +1191,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,6 +1387,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "normpath"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8911957c4b1549ac0dc74e30db9c8b0e66ddcd6d7acc33098f4c63a64a6d7ed"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "num-modular"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,6 +1449,18 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "opener"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0812e5e4df08da354c851a3376fead46db31c2214f849d3de356d774d057681"
+dependencies = [
+ "bstr",
+ "dbus",
+ "normpath",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "openssl"
@@ -2040,6 +2093,7 @@ dependencies = [
  "handlebars",
  "libloading",
  "log",
+ "opener",
  "pretty_assertions",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ reqwest = { version = "0.12", features = ["json"] }
 toml = "0.8"
 # Directory utilities
 dirs = "6.0"
+# Cross-platform browser opening
+opener = "0.7"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A comprehensive security analysis tool for Solana smart contracts that helps dev
 - **Multiple Report Formats**: JSON, HTML, Markdown, and CSV outputs
 - **Plugin System**: Extensible architecture for custom security rules
 - **CI/CD Integration**: GitHub Actions support with automated security checks
-- **Professional Reports**: Beautiful HTML reports with severity rankings and actionable recommendations
+- **Professional Reports**: HTML reports with severity rankings and actionable recommendations
 - **Smart Error Handling**: Clear, colored error messages with proper path validation
 - **Comprehensive Examples**: 8 educational examples demonstrating vulnerabilities and secure patterns
 
@@ -52,7 +52,7 @@ solsec scan ./my-program --html-only --output results.html
 # Generate multiple formats at once
 solsec scan ./my-program --format json,html,markdown,csv
 
-# Don't open browser automatically (useful for CI/automation)
+# Don't open browser automatically
 solsec scan ./my-program --no-open
 
 # Run fuzz testing
@@ -63,9 +63,9 @@ solsec fuzz ./my-solana-program --timeout 300
 
 ### `solsec scan`
 
-Run static analysis on your Solana smart contracts. Generates both JSON and HTML If no path is provided, it recursively scans the current directory for all `.rs` files, automatically ignoring `target/` and `.git/` folders.
+Run static analysis on your Solana smart contracts. Generates both JSON and HTML by default. If no path is provided, it recursively scans the current directory for all `.rs` files, automatically ignoring `target/` and `.git/` folders.
 
-HTML reports automatically open in your default browser when running interactively, but remain closed in CI/automation environments.
+HTML reports automatically open in the default browser when running interactively, but remain closed in CI/automation environments.
 
 ```bash
 solsec scan [PATH] [OPTIONS]
@@ -74,25 +74,25 @@ OPTIONS:
     -c, --config <FILE>          Configuration file path
     -o, --output <DIR>           Output directory [default: ./solsec-results]
     -f, --format <FORMATS>       Output formats (comma-separated) [default: json,html] [possible values: json, html, markdown, csv]
-        --json-only              Only generate JSON (perfect for CI/CD)
-        --html-only              Only generate HTML (perfect for humans)
+        --json-only              Only generate JSON
+        --html-only              Only generate HTML
         --no-open                Don't automatically open HTML report in browser
         --fail-on-critical       Exit with non-zero code on critical issues [default: true]
 
 EXAMPLES:
-    # Scan the entire project (generates both JSON and HTML, opens in browser!)
+    # Scan the entire project (generates both JSON and HTML)
     solsec scan
 
     # Scan a specific directory with default formats
     solsec scan ./programs/my-program
     
-    # Generate only JSON for CI/CD integration (no browser opening)
+    # Generate only JSON for CI/CD integration
     solsec scan ./programs --json-only --output results.json
 
-    # Generate only HTML for manual review (opens in browser)
+    # Generate only HTML for manual review
     solsec scan ./programs --html-only --output results.html
 
-    # Generate HTML but don't open browser (useful for automation)
+    # Generate HTML but don't open browser
     solsec scan ./programs --html-only --no-open --output results.html
 
     # Generate all available formats
@@ -308,35 +308,32 @@ rm -rf ./tmp-security-results
 echo "✅ Security scan passed!"
 ```
 
-## 🌐 Smart Browser Opening
+## Browser Opening Behavior
 
-**Automatic browser opening** when generating HTML reports makes reviewing security findings effortless:
+HTML reports automatically open in the default browser under the following conditions:
 
-**✅ Opens automatically when:**
+**Opens automatically when:**
 - Running in an interactive terminal (not redirected)
 - Generating HTML reports (`--html-only` or default formats)
 - Not in CI/automation environments
 
-**❌ Stays closed when:**
+**Remains closed when:**
 - Running in CI environments (GitHub Actions, GitLab CI, etc.)
 - Output is redirected or piped
 - Using `--no-open` flag
 - Only generating non-visual formats (JSON, CSV)
 
-This gives you the best of both worlds: **great UX for developers** and **automation-friendly behavior** for CI/CD.
-
 ## 📊 Report Examples
 
 ### HTML Report
-Beautiful, interactive HTML reports with:
+Interactive HTML reports with:
 - Executive summary with issue counts by severity
 - Detailed findings with code snippets
 - Actionable recommendations
 - Responsive design for all devices
-- **Auto-opens in your browser for immediate review!**
 
 ### JSON Report
-Machine-readable format perfect for:
+Machine-readable format for:
 - CI/CD pipeline integration
 - Custom tooling and analysis
 - Data processing and metrics
@@ -395,7 +392,7 @@ solsec scan examples/unchecked_account/vulnerable.rs    # 6 issues found
 solsec scan examples/reentrancy/vulnerable.rs           # 2 issues found
 
 # Test secure examples (should find 0 issues)
-solsec scan examples/*/secure.rs                        # All pass!
+solsec scan examples/*/secure.rs                        # No issues found
 
 # Comprehensive analysis
 solsec scan examples/                                    # 26 total issues across all vulnerable examples

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ solsec scan ./my-program --html-only --output results.html
 # Generate multiple formats at once
 solsec scan ./my-program --format json,html,markdown,csv
 
+# Don't open browser automatically (useful for CI/automation)
+solsec scan ./my-program --no-open
+
 # Run fuzz testing
 solsec fuzz ./my-solana-program --timeout 300
 ```
@@ -62,6 +65,8 @@ solsec fuzz ./my-solana-program --timeout 300
 
 Run static analysis on your Solana smart contracts. Generates both JSON and HTML If no path is provided, it recursively scans the current directory for all `.rs` files, automatically ignoring `target/` and `.git/` folders.
 
+HTML reports automatically open in your default browser when running interactively, but remain closed in CI/automation environments.
+
 ```bash
 solsec scan [PATH] [OPTIONS]
 
@@ -71,25 +76,29 @@ OPTIONS:
     -f, --format <FORMATS>       Output formats (comma-separated) [default: json,html] [possible values: json, html, markdown, csv]
         --json-only              Only generate JSON (perfect for CI/CD)
         --html-only              Only generate HTML (perfect for humans)
+        --no-open                Don't automatically open HTML report in browser
         --fail-on-critical       Exit with non-zero code on critical issues [default: true]
 
 EXAMPLES:
-    # Scan the entire project (generates both JSON and HTML!)
+    # Scan the entire project (generates both JSON and HTML, opens in browser!)
     solsec scan
 
     # Scan a specific directory with default formats
     solsec scan ./programs/my-program
     
-    # Generate only JSON for CI/CD integration  
+    # Generate only JSON for CI/CD integration (no browser opening)
     solsec scan ./programs --json-only --output results.json
 
-    # Generate only HTML for manual review
+    # Generate only HTML for manual review (opens in browser)
     solsec scan ./programs --html-only --output results.html
+
+    # Generate HTML but don't open browser (useful for automation)
+    solsec scan ./programs --html-only --no-open --output results.html
 
     # Generate all available formats
     solsec scan ./programs --format json,html,markdown,csv
 
-    # Legacy: Scan with configuration file
+    # Scan with configuration file
     solsec scan ./programs --config solsec.toml --output ./security-results
 ```
 
@@ -299,6 +308,23 @@ rm -rf ./tmp-security-results
 echo "✅ Security scan passed!"
 ```
 
+## 🌐 Smart Browser Opening
+
+**Automatic browser opening** when generating HTML reports makes reviewing security findings effortless:
+
+**✅ Opens automatically when:**
+- Running in an interactive terminal (not redirected)
+- Generating HTML reports (`--html-only` or default formats)
+- Not in CI/automation environments
+
+**❌ Stays closed when:**
+- Running in CI environments (GitHub Actions, GitLab CI, etc.)
+- Output is redirected or piped
+- Using `--no-open` flag
+- Only generating non-visual formats (JSON, CSV)
+
+This gives you the best of both worlds: **great UX for developers** and **automation-friendly behavior** for CI/CD.
+
 ## 📊 Report Examples
 
 ### HTML Report
@@ -307,6 +333,7 @@ Beautiful, interactive HTML reports with:
 - Detailed findings with code snippets
 - Actionable recommendations
 - Responsive design for all devices
+- **Auto-opens in your browser for immediate review!**
 
 ### JSON Report
 Machine-readable format perfect for:

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,18 +33,20 @@ async fn main() -> Result<()> {
             format,
             json_only,
             html_only,
+            no_open,
             fail_on_critical,
         } => {
-            cli::handle_scan_command(
+            let scan_config = cli::ScanConfig {
                 path,
                 config,
                 output,
-                format,
+                formats: format,
                 json_only,
                 html_only,
+                no_open,
                 fail_on_critical,
-            )
-            .await
+            };
+            cli::handle_scan_command(scan_config).await
         }
         Commands::Fuzz {
             path,

--- a/src/report.rs
+++ b/src/report.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use crate::analyzer::AnalysisResult;
 use crate::fuzz::FuzzResult;
 
-#[derive(Debug, Clone, ValueEnum, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, ValueEnum, Serialize, Deserialize)]
 pub enum ReportFormat {
     Json,
     Html,


### PR DESCRIPTION
This pull request introduces a new feature to control browser opening behavior for HTML reports, refactors the CLI configuration for better maintainability, and updates documentation to reflect these changes. The most significant updates include adding a `--no-open` flag, restructuring the `ScanConfig` to centralize configuration management, and enhancing the user experience with clearer documentation and examples.

### New Feature: Browser Opening Control

* Added a `--no-open` flag to prevent automatic opening of HTML reports in the browser. This flag is useful for CI environments and automation workflows. (`src/cli.rs`, `README.md`) [[1]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR61-R64) [[2]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccL84-R121) [[3]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR229-R290) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R55-R57) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L72-R83) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R95-R101) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R311-R336)

### Refactoring: Centralized Configuration

* Introduced a `ScanConfig` struct to encapsulate all scan-related configurations, simplifying the `handle_scan_command` function and improving maintainability. (`src/cli.rs`, `src/main.rs`) [[1]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR11-R22) [[2]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccL84-R121) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR36-R49)

### Documentation Updates

* Updated the `README.md` to reflect the new `--no-open` flag, clarify browser opening behavior, and improve examples for better user understanding. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R55-R57) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-R68) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R95-R101) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R311-R336) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L371-R395)

### Dependency Addition

* Added the `opener` crate to handle cross-platform browser opening for HTML reports. (`Cargo.toml`)

### Minor Enhancements

* Added `PartialEq` to the `ReportFormat` enum to support comparisons, which is used in determining browser opening conditions. (`src/report.rs`)